### PR TITLE
Update README with a link to the live a16z AI Playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AI-Playbook
 
 ## Production URL
-The latest non-dev version of this app is running at [Live AI Playground](http://localhost) - TODO update with final URL
+The latest non-dev version of this app is running at [Live AI Playground](http://aiplaybook.a16z.com/).
 
 ## Releasing to Production
 Releasing to a Heroku app/account requires the appropriate setup, including environment variables (see below).


### PR DESCRIPTION
This is live now, so the link can be updated from http://localhost to http://aiplaybook.a16z.com/.

Fixes #64.